### PR TITLE
docs: link to the pulumi template project

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@
 Using this template in a new project? See CONTIBUTING.md for help.
 --->
 
-This repo contains instructions for the ["Pulumi Equinix Fabric Cloud Router" workshop](https://equinix-labs.github.io/pulumi-equinix-fabric-cloud-router-workshop).
+This repo contains step-by-step instructions for using the ["Pulumi Equinix Fabric Cloud Router" Pulumi template](https://github.com/equinix-labs/pulumi-equinix-fabric-cloud-router-gcp).
 
 To view the workshop, visit <https://equinix-labs.github.io/pulumi-equinix-fabric-cloud-router-workshop>


### PR DESCRIPTION
link to the pulumi template project in addition to linking to the GitHub.io hosted workshop